### PR TITLE
Add cosmicvault.owns.it.com for CosmicVault NASA space blog

### DIFF
--- a/domains/cosmicvault.json
+++ b/domains/cosmicvault.json
@@ -1,0 +1,13 @@
+{
+  "description": "CosmicVault - A space exploration blog using NASA's open APIs to showcase astronomy pictures, Mars rover photos, and asteroid tracking data.",
+  "domain": "owns.it.com",
+  "subdomain": "cosmicvault",
+  "owner": {
+    "repo": "https://github.com/mohankumaronly/Cosmicvault",
+    "email": "mohankumaronly81@gmail.com"
+  },
+  "record": {
+    "CNAME": "cosmicvault-smoky.vercel.app"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Registering cosmicvault.owns.it.com for my NASA space blog CosmicVault.

Project: https://github.com/mohankumaronly/Cosmicvault
Live at: https://cosmicvault-smoky.vercel.app

This is a legitimate educational project using NASA's open APIs.