### PR TITLE
Add petatus.owns.it.com domain for V2Ray Config Checker

### DIFF
--- a/domains/petatus.owns.it.com.json
+++ b/domains/petatus.owns.it.com.json
@@ -1,16 +1,13 @@
 {
-    "description": "My personal project",
-    "domain": "owns.it.com",
-    "subdomain": "petatus",
-
-    "owner": {
-        "repo": "https://github.com/mory524/register",
-        "email": "morypory@gmail.com"
-    },
-
-    "record": {
-        "CNAME": "black-wind-09d2.morypory-1bc.workers.dev"
-    },
-
-    "proxied": false
+  "description": "My V2Ray Config Checker",
+  "domain": "owns.it.com",
+  "subdomain": "petatus",
+  "owner": {
+    "repo": "https://github.com/mory524/my-v2ray-checker",
+    "email": "morypory@gmail.com"
+  },
+  "record": {
+    "CNAME": "mory524.github.io"
+  },
+  "proxied": false
 }

--- a/domains/petatus.owns.it.com.json
+++ b/domains/petatus.owns.it.com.json
@@ -1,0 +1,16 @@
+{
+    "description": "My personal project",
+    "domain": "owns.it.com",
+    "subdomain": "petatus",
+
+    "owner": {
+        "repo": "https://github.com/mory524/register",
+        "email": "morypory@gmail.com"
+    },
+
+    "record": {
+        "CNAME": "black-wind-09d2.morypory-1bc.workers.dev"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
I'm using this subdomain for my V2Ray Config Checker PWA hosted on GitHub Pages at mory524.github.io/my-v2ray-checker. The DNS record is set to CNAME pointing to mory524.github.io.