### PR TITLE
Add petatus.owns.it.com domain for V2Ray Config Checker

### DIFF
--- a/domains/petatus.owns.it.com.json
+++ b/domains/petatus.owns.it.com.json
@@ -1,16 +1,13 @@
 {
-    "description": "My personal project",
-    "domain": "owns.it.com",
-    "subdomain": "petatus",
-
-    "owner": {
-        "repo": "https://github.com/mory524/register",
-        "email": "morypory@gmail.com"
-    },
-
-    "record": {
-        "CNAME": "black-wind-09d2.morypory-1bc.workers.dev"
-    },
-
-    "proxied": false
+  "description": "My V2Ray Config Checker",
+  "domain": "owns.it.com",
+  "subdomain": "petatus",
+  "owner": {
+    "repo": "https://github.com/mory524/my-v2ray-checker",
+    "email": "morypory@gmail.com"
+  },
+  "record": {
+    "CNAME": "mory524.github.io"
+  },
+  "proxied": false
 }

--- a/domains/petatus.owns.it.com.json
+++ b/domains/petatus.owns.it.com.json
@@ -1,0 +1,16 @@
+{
+    "description": "My personal project",
+    "domain": "owns.it.com",
+    "subdomain": "petatus",
+
+    "owner": {
+        "repo": "https://github.com/mory524/register",
+        "email": "morypory@gmail.com"
+    },
+
+    "record": {
+        "CNAME": "black-wind-09d2.morypory-1bc.workers.dev"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
This PR adds the subdomain `petatus.owns.it.com` for my V2Ray Config Checker PWA tool hosted on GitHub Pages.

- **Subdomain:** petatus
- **Domain:** owns.it.com
- **Record Type:** CNAME
- **Target:** mory524.github.io
- **Repository:** https://github.com/mory524/my-v2ray-checker

All validation checks have passed. Please review and merge. Thank you!