### PR TITLE
Add goldenplate.owns.it.com

### DIFF
--- a/domains/goldenplate.owns.it.com.json
+++ b/domains/goldenplate.owns.it.com.json
@@ -1,0 +1,13 @@
+{
+    "description": "Golden Plate Restaurant - Premium dining in Addis Ababa, Bole",
+    "domain": "owns.it.com",
+    "subdomain": "goldenplate",
+    "owner": {
+        "repo": "https://github.com/M1616D/Golden-Plate",
+        "email": "bereket1515mamuye@gmail.com"
+    },
+    "record": {
+        "CNAME": "m1616d.github.io"
+    },
+    "proxied": false
+}


### PR DESCRIPTION
Registering goldenplate.owns.it.com for Golden Plate Restaurant

- Domain: goldenplate.owns.it.com
- Target: m1616d.github.io
- Repository: M1616D/Golden-Plate
- Purpose: Professional domain for Golden Plate Restaurant website