### PR TITLE
register dihagent.owns.it.com (Railway dashboard)

### DIFF
--- a/domains/dihagent.owns.it.com.json
+++ b/domains/dihagent.owns.it.com.json
@@ -1,0 +1,13 @@
+{
+    "description": "DihSpeed trading-agent dashboard (paper trading bot), hosted on Railway",
+    "domain": "owns.it.com",
+    "subdomain": "dihagent",
+    "owner": {
+        "repo": "https://github.com/onlydeployyyessss/dihspeed-agent",
+        "email": "onlydeployyyessss@users.noreply.github.com"
+    },
+    "record": {
+        "CNAME": "dihspeed-production.up.railway.app"
+    },
+    "proxied": true
+}


### PR DESCRIPTION
DihSpeed is a personal paper-trading agent (prediction-market simulator, no real money) hosted on Railway. Its dashboard needs a stable, memorable address.

- Target verified reachable: `https://dihspeed-production.up.railway.app` returns HTTP 200 right now.
- Repo: https://github.com/onlydeployyyessss/dihspeed-agent
- No NS records needed, no wildcard — a single CNAME subdomain.
